### PR TITLE
Changed from ssh url to https url for heroku nginx buildpack.

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,6 @@
   "addons": [],
   "buildpacks": [
       {"url": "heroku/clojure"},
-      {"url": "git@github.com:WeatherMagic/nginx-buildpack.git"}
+      {"url": "https://github.com/WeatherMagic/nginx-buildpack.git"}
   ]
 }


### PR DESCRIPTION
This should fix the Heroku errors in current PR:s, trust me :D
