### PR TITLE
Made it so that the jenkins build-status displayed in the README is that of the master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Weather Front
 
-[![Build Status](https://travis-ci.org/WeatherMagic/weather-front.svg?branch=travis)](https://travis-ci.org/WeatherMagic/weather-front)
+[![Build Status](https://travis-ci.org/WeatherMagic/weather-front.svg?branch=master)](https://travis-ci.org/WeatherMagic/weather-front)
 
 A WebGL ClojureScript front visualizing climate change models.
 


### PR DESCRIPTION
Right now the badge on https://github.com/WeatherMagic/weather-front says build error because its pointing at a branch that no longer exists. I'm correcting this and pointing it at the test results of the master branch.
