### PR TITLE
Added .lein-failures to the list of things for git to actively ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pom.xml
 /target/
 .lein-deps-sum
 .lein-repl-history
+.lein-failures
 .lein-plugins/
 .repl
 .nrepl-port


### PR DESCRIPTION
In order to test this, try to tell git to add a file with the name `.lein-failures`.
