### PR TITLE
Made texture loading dynamic

### DIFF
--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -43,9 +43,9 @@
       (cam/apply camera)))
 
 (defn draw-frame! [t]
-  (when (= @state/textures-loaded @state/textures-to-be-loaded)
-    (gl/bind @state/texture 0)
-    (gl/bind textures/trump 1)
+  (when (and @(:loaded @state/texture) @(:loaded textures/trump))
+    (gl/bind (:texture @state/texture) 0)
+    (gl/bind (:texture textures/trump) 1)
     (doto state/gl-ctx
       (gl/clear-color-and-depth-buffer 0 0 0 1 1)
       (gl/draw-with-shader (assoc-in (combine-model-shader-and-camera @state/model @state/current-shader @state/camera t)

--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -26,7 +26,7 @@
 
 (defn set-model-matrix
   [t]
-  (@state/earth-animation-fn t)
+  (@state/earth-animation-fn @state/textures t)
   (let [earth-orientation @state/earth-orientation]
     (-> M44
         (g/translate (:translation earth-orientation))
@@ -43,12 +43,14 @@
       (cam/apply camera)))
 
 (defn draw-frame! [t]
-  (when (and @(:loaded @state/texture) @(:loaded textures/trump))
-    (gl/bind (:texture @state/texture) 0)
-    (gl/bind (:texture textures/trump) 1)
+  (when (and @(:loaded @state/base-texture) @(:loaded (:trump @state/textures)))
+    (gl/bind (:texture @state/base-texture) 0)
+    (gl/bind (:texture (:trump @state/textures)) 1)
     (doto state/gl-ctx
       (gl/clear-color-and-depth-buffer 0 0 0 1 1)
-      (gl/draw-with-shader (assoc-in (combine-model-shader-and-camera @state/model @state/current-shader @state/camera t)
+      (gl/draw-with-shader (assoc-in (combine-model-shader-and-camera @state/model
+                                                                      @state/current-shader
+                                                                      @state/camera t)
                                      [:uniforms :model] (set-model-matrix t))))))
 
 ;; Start the demo only once.

--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -26,7 +26,7 @@
 
 (defn set-model-matrix
   [t]
-  (@state/earth-animation-fn @state/textures t)
+  (@state/earth-animation-fn t)
   (let [earth-orientation @state/earth-orientation]
     (-> M44
         (g/translate (:translation earth-orientation))

--- a/src/weather_magic/state.cljs
+++ b/src/weather_magic/state.cljs
@@ -39,7 +39,3 @@
 (defonce texture (atom nil))
 
 (defonce current-shader (atom shaders/standard-shader-spec))
-
-;; Counters for texture loading.
-(defonce textures-loaded (volatile! 0))
-(defonce textures-to-be-loaded (volatile! 0))

--- a/src/weather_magic/state.cljs
+++ b/src/weather_magic/state.cljs
@@ -1,6 +1,7 @@
 (ns weather-magic.state
   (:require
    [weather-magic.models  :as models]
+   [weather-magic.textures  :as textures]
    [thi.ng.geom.gl.camera :as cam]
    [thi.ng.geom.gl.core   :as gl]
    [weather-magic.shaders :as shaders]
@@ -35,7 +36,9 @@
 ;; Whether or not the landing page is visible.
 (defonce intro-visible (atom :visible))
 
-(defonce model   (atom models/sphere))
-(defonce texture (atom nil))
+(defonce model        (atom models/sphere))
+
+(defonce textures     (atom (textures/load-base-textures gl-ctx)))
+(defonce base-texture (atom (:earth @textures)))
 
 (defonce current-shader (atom shaders/standard-shader-spec))

--- a/src/weather_magic/textures.cljs
+++ b/src/weather_magic/textures.cljs
@@ -1,22 +1,48 @@
 (ns weather-magic.textures
   (:require
    [weather-magic.state            :as state]
+   [weather-magic.util             :as util]
    [thi.ng.geom.gl.buffers         :as buf]
    [thi.ng.geom.gl.webgl.constants :as glc]))
 
-(defn load-texture [path]
-  (vswap! state/textures-to-be-loaded inc)
-  (buf/load-texture
-   state/gl-ctx {:callback (fn [tex img]
-                             (.generateMipmap state/gl-ctx (:target tex))
-                             (vswap! state/textures-loaded inc))
-                 :src      path
-                 :filter   [glc/linear-mipmap-linear glc/linear]
-                 :flip     false}))
+(defn load-texture [gl-ctx path]
+  "Loads a texture from path and places it in a map along with a
+  volatile indicating whether or not the texture has been loaded
+  like: {:texture T :loaded (volatile! false)}"
+  (let [loaded (volatile! false)
+        texture (buf/load-texture
+                 state/gl-ctx {:callback
+                               (fn [tex img]
+                                 (.generateMipmap state/gl-ctx (:target tex))
+                                 (vreset! loaded true))
+                               :src      path
+                               :filter   [glc/linear-mipmap-linear glc/linear]})]
+    {:texture texture :loaded loaded}))
 
-(defonce earth  (load-texture "img/earth.jpg"))
-(defonce trump  (load-texture "img/trump.png"))
-(defonce turkey (load-texture "img/turkey.jpg"))
+(defn load-texture-if-needed
+  [gl-ctx textures & paths]
+  "Load a texture from the given path into the given WebGL context and
+  a reference to it along with an inticator as to whether the texture
+  has loaded or not into the given map.
+
+  If the given path is '/img/earth.jpg' the texture will be entered
+  into the map with the key :earth and it's value will be another map
+  with two keys, :loaded and :texture where :loaded is the boolean
+  true or false whether the texture is ready to use and :texture
+  eventually holds the actual texture ready for use.
+
+  So (load-texture X {} 'earth.png') will return:
+    {:earth {:texture T :loaded (volatile! false)}}
+  where :loaded will turn true once the load is complete."
+  (into textures
+        (for [path paths]
+          (let [name (util/get-filename path)]
+            (when-not (contains? textures name)
+              {(keyword name) (load-texture gl-ctx path)})))))
+
+(defonce earth  (load-texture state/gl-ctx "img/earth.jpg"))
+(defonce trump  (load-texture state/gl-ctx "img/trump.png"))
+(defonce turkey (load-texture state/gl-ctx "img/turkey.jpg"))
 
 ;; THIS IS BAD AND I SHOULD FEEL BAD.
 (reset! state/texture earth)

--- a/src/weather_magic/textures.cljs
+++ b/src/weather_magic/textures.cljs
@@ -1,6 +1,5 @@
 (ns weather-magic.textures
   (:require
-   [weather-magic.state            :as state]
    [weather-magic.util             :as util]
    [thi.ng.geom.gl.buffers         :as buf]
    [thi.ng.geom.gl.webgl.constants :as glc]))
@@ -11,12 +10,12 @@
   like: {:texture T :loaded (volatile! false)}"
   (let [loaded (volatile! false)
         texture (buf/load-texture
-                 state/gl-ctx {:callback
-                               (fn [tex img]
-                                 (.generateMipmap state/gl-ctx (:target tex))
-                                 (vreset! loaded true))
-                               :src      path
-                               :filter   [glc/linear-mipmap-linear glc/linear]})]
+                 gl-ctx {:callback
+                         (fn [tex img]
+                           (.generateMipmap gl-ctx (:target tex))
+                           (vreset! loaded true))
+                         :src      path
+                         :filter   [glc/linear-mipmap-linear glc/linear]})]
     {:texture texture :loaded loaded}))
 
 (defn load-texture-if-needed
@@ -40,9 +39,6 @@
             (when-not (contains? textures name)
               {(keyword name) (load-texture gl-ctx path)})))))
 
-(defonce earth  (load-texture state/gl-ctx "img/earth.jpg"))
-(defonce trump  (load-texture state/gl-ctx "img/trump.png"))
-(defonce turkey (load-texture state/gl-ctx "img/turkey.jpg"))
-
-;; THIS IS BAD AND I SHOULD FEEL BAD.
-(reset! state/texture earth)
+(defn load-base-textures
+  [gl-ctx]
+  (load-texture-if-needed gl-ctx {} "img/earth.jpg" "img/trump.png"))

--- a/src/weather_magic/util.cljs
+++ b/src/weather_magic/util.cljs
@@ -1,8 +1,7 @@
 (ns weather-magic.util
   (:require
    [thi.ng.geom.gl.buffers :as buf]
-   [thi.ng.geom.gl.webgl.constants :as glc]
-   [weather-magic.state            :as state]))
+   [thi.ng.geom.gl.webgl.constants :as glc]))
 
 (defn transparent-println
   "Print something and return that something."

--- a/src/weather_magic/util.cljs
+++ b/src/weather_magic/util.cljs
@@ -16,3 +16,12 @@
   [set item]
   (transparent-println
    ((if (contains? set item) disj conj) set item)))
+
+(defn get-filename
+  "Get the name of the file in the given path. Cuts out folder and
+  file name extension. Returns nil if no file is found in the path."
+  [path]
+  ;; Match characters which aren't the literal '/' or '.' (the file
+  ;; name), possibly followed by a '.' and some characters not '/' (the
+  ;; filename extension), always ended with a line ending.
+  (second (re-find #"([^/^\.]+)\.?[^/]*$" path)))

--- a/src/weather_magic/world.cljs
+++ b/src/weather_magic/world.cljs
@@ -9,25 +9,28 @@
 
 (defn show-europe!
   "Rotates the sphere so that Europe is shown."
-  [t]
+  [textures t]
   (reset! state/model models/sphere)
-  (reset! state/texture textures/earth)
+  (reset! state/base-texture (:earth textures))
   (swap!  state/earth-orientation assoc
           :x-angle 45 :y-angle 80 :z-angle 0 :translation (vec3 0 0 0)))
 
 (defn show-turkey!
   "Shows Turkey on a flat surface."
-  [t]
+  [textures t]
+  (swap!  state/textures merge
+          (textures/load-texture-if-needed state/gl-ctx @state/textures "img/turkey.jpg"))
   (reset! state/model models/plane)
-  (reset! state/texture textures/turkey)
+  (reset! state/base-texture (:turkey textures))
   (swap!  state/earth-orientation assoc
           :x-angle 0  :y-angle 0 :z-angle 180 :translation (vec3 2 1.5 0)))
 
 (defn spin-earth!
   "Rotates the sphere indefinitely."
-  [t]
+  [textures t]
   (reset! state/model models/sphere)
-  (reset! state/texture textures/earth)
+  (reset! state/base-texture (:earth textures))
+
   (swap!  state/earth-orientation assoc
           :x-angle 24 :y-angle t :z-angle 0 :translation (vec3 0 0 0)))
 

--- a/src/weather_magic/world.cljs
+++ b/src/weather_magic/world.cljs
@@ -9,28 +9,28 @@
 
 (defn show-europe!
   "Rotates the sphere so that Europe is shown."
-  [textures t]
+  [t]
   (reset! state/model models/sphere)
-  (reset! state/base-texture (:earth textures))
+  (reset! state/base-texture (:earth @state/textures))
   (swap!  state/earth-orientation assoc
           :x-angle 45 :y-angle 80 :z-angle 0 :translation (vec3 0 0 0)))
 
 (defn show-turkey!
   "Shows Turkey on a flat surface."
-  [textures t]
+  [t]
   (swap!  state/textures merge
           (textures/load-texture-if-needed state/gl-ctx @state/textures "img/turkey.jpg"))
   (reset! state/model models/plane)
-  (reset! state/base-texture (:turkey textures))
+  (reset! state/base-texture (:turkey @state/textures))
+  (println state/base-texture)
   (swap!  state/earth-orientation assoc
           :x-angle 0  :y-angle 0 :z-angle 180 :translation (vec3 2 1.5 0)))
 
 (defn spin-earth!
   "Rotates the sphere indefinitely."
-  [textures t]
+  [t]
   (reset! state/model models/sphere)
-  (reset! state/base-texture (:earth textures))
-
+  (reset! state/base-texture (:earth @state/textures))
   (swap!  state/earth-orientation assoc
           :x-angle 24 :y-angle t :z-angle 0 :translation (vec3 0 0 0)))
 


### PR DESCRIPTION
This pull request modifies no user facing functionality but restructures the semantics around loading textures.

There now exists one map `state/textures` which is a map of every texture loaded into the application. There are no longer any statically specified textures but each texture is placed into this dynamic map when it is loaded.

The main entry point for loading textures is now `load-texture-if-needed` which will add a texture to the textures map and start asynchronically loading it into the application given that it's not already loaded. If it's already loaded it does nothing.

Each texture now has its own indicator as to whether its loaded or not, and a textures map with one texture will look like:

```clojure
{:earth {:texture T :loaded (volatile! false)}}
```
