### PR TITLE
Made it so that we don't compile the shader every frame

### DIFF
--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -28,11 +28,10 @@
   (@state/earth-animation-fn delta-time)
   (m/* M44 @state/earth-orientation))
 
-(defn combine-model-shader-and-camera
-  [model shader camera t]
+(defn combine-model-and-camera
+  [model camera t]
   (-> model
       (gl/as-gl-buffer-spec {})
-      (assoc :shader shader)
       (gl/make-buffers-in-spec state/gl-ctx glc/static-draw)
       (cam/apply camera)))
 
@@ -46,7 +45,8 @@
       (doto state/gl-ctx
         (gl/clear-color-and-depth-buffer 0 0 0 1 1)
         (gl/draw-with-shader
-         (-> (combine-model-shader-and-camera @state/model @state/current-shader @state/camera t)
+         (-> (combine-model-and-camera @state/model @state/camera t)
+             (assoc :shader (@state/current-shader-key state/shaders))
              (assoc-in [:uniforms :model] (set-model-matrix (- t @state/time-of-last-frame)))
              (assoc-in [:uniforms :year]  time)
              (assoc-in [:uniforms :range] range))))

--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -5,15 +5,14 @@
    [weather-magic.shaders          :as shaders]
    [weather-magic.textures         :as textures]
    [weather-magic.event-handlers   :as event-handlers]
-   [thi.ng.math.core               :as m :refer [PI HALF_PI TWO_PI]]
+   [thi.ng.math.core               :as m   :refer [PI HALF_PI TWO_PI]]
    [thi.ng.geom.gl.core            :as gl]
    [thi.ng.geom.gl.webgl.constants :as glc]
    [thi.ng.geom.gl.webgl.animator  :as anim]
-   [thi.ng.geom.gl.shaders         :as sh]
    [thi.ng.geom.gl.glmesh          :as glm]
    [thi.ng.geom.gl.camera          :as cam]
    [thi.ng.geom.core               :as g]
-   [thi.ng.geom.vector             :as v :refer [vec2 vec3]]
+   [thi.ng.geom.vector             :as v   :refer [vec2 vec3]]
    [thi.ng.geom.matrix             :as mat :refer [M44]]
    [thi.ng.geom.sphere             :as s]
    [thi.ng.geom.attribs            :as attr]
@@ -30,10 +29,10 @@
   (m/* M44 @state/earth-orientation))
 
 (defn combine-model-shader-and-camera
-  [model shader-spec camera t]
+  [model shader camera t]
   (-> model
       (gl/as-gl-buffer-spec {})
-      (assoc :shader (sh/make-shader-from-spec state/gl-ctx shader-spec))
+      (assoc :shader shader)
       (gl/make-buffers-in-spec state/gl-ctx glc/static-draw)
       (cam/apply camera)))
 

--- a/src/weather_magic/shaders.cljs
+++ b/src/weather_magic/shaders.cljs
@@ -1,10 +1,10 @@
 (ns weather-magic.shaders
   (:require
-   [thi.ng.geom.gl.core :as gl]
-   [thi.ng.glsl.core :as glsl :include-macros true]
-   [thi.ng.glsl.vertex             :as vertex]
-   [thi.ng.glsl.lighting           :as light]
-   [thi.ng.geom.matrix             :as mat :refer [M44]]))
+   [thi.ng.geom.gl.core  :as gl]
+   [thi.ng.glsl.core     :as glsl :include-macros true]
+   [thi.ng.glsl.vertex   :as vertex]
+   [thi.ng.glsl.lighting :as light]
+   [thi.ng.geom.matrix   :as mat :refer [M44]]))
 
 (def standard-vs
   "void main() {
@@ -18,7 +18,7 @@
      float lam = lambert(surfaceNormal(vNormal, normalMat),
                          normalize(lightDir));
      vec4 diffuse = texture2D(base, vUV) + texture2D(trump, vUV);
-     vec4 col = vec4(ambientCol, 1.0) + diffuse * vec4(lightCol, 1.0) * lam;
+     vec4 col = vec4(ambientCol, 1.0) + diffuse * vec4(lightCol, 1.0) * lam + 0.0;
      gl_FragColor = col;
    }")
 

--- a/src/weather_magic/shaders.cljs
+++ b/src/weather_magic/shaders.cljs
@@ -18,7 +18,7 @@
      float lam = lambert(surfaceNormal(vNormal, normalMat),
                          normalize(lightDir));
      vec4 diffuse = texture2D(base, vUV) + texture2D(trump, vUV);
-     vec4 col = vec4(ambientCol, 1.0) + diffuse * vec4(lightCol, 1.0) * lam + 0.0;
+     vec4 col = vec4(ambientCol, 1.0) + diffuse * vec4(lightCol, 1.0) * lam;
      gl_FragColor = col;
    }")
 

--- a/src/weather_magic/state.cljs
+++ b/src/weather_magic/state.cljs
@@ -41,8 +41,10 @@
 (defonce textures     (atom (textures/load-base-textures gl-ctx)))
 (defonce base-texture (atom (:earth @textures)))
 
-(defonce current-shader (atom (sh/make-shader-from-spec gl-ctx shaders/standard-shader-spec)))
-
+(def shaders {:standard (sh/make-shader-from-spec gl-ctx shaders/standard-shader-spec)
+              :blend    (sh/make-shader-from-spec gl-ctx shaders/blend-shader-spec)
+              :temp     (sh/make-shader-from-spec gl-ctx shaders/temperature-shader-spec)})
+(defonce current-shader-key (atom :standard))
 
 ;; Used for determining frame delta, the time between each frame.
 (defonce time-of-last-frame (volatile! 0))

--- a/src/weather_magic/state.cljs
+++ b/src/weather_magic/state.cljs
@@ -1,13 +1,14 @@
 (ns weather-magic.state
   (:require
-   [weather-magic.models  :as models]
-   [weather-magic.textures  :as textures]
-   [thi.ng.geom.gl.camera :as cam]
-   [thi.ng.geom.gl.core   :as gl]
-   [weather-magic.shaders :as shaders]
-   [thi.ng.geom.vector    :as v :refer [vec2 vec3]]
-   [reagent.core          :refer [atom]]
-   [thi.ng.geom.matrix :as mat :refer [M44]]))
+   [weather-magic.models   :as models]
+   [weather-magic.shaders  :as shaders]
+   [weather-magic.textures :as textures]
+   [thi.ng.geom.gl.camera  :as cam]
+   [thi.ng.geom.gl.core    :as gl]
+   [thi.ng.geom.gl.shaders :as sh]
+   [thi.ng.geom.vector     :as v   :refer [vec2 vec3]]
+   [reagent.core                   :refer [atom]]
+   [thi.ng.geom.matrix     :as mat :refer [M44]]))
 
 ;; Our WebGL context, given by the browser.
 (defonce gl-ctx (gl/gl-context "main"))
@@ -40,7 +41,8 @@
 (defonce textures     (atom (textures/load-base-textures gl-ctx)))
 (defonce base-texture (atom (:earth @textures)))
 
-(defonce current-shader (atom shaders/standard-shader-spec))
+(defonce current-shader (atom (sh/make-shader-from-spec gl-ctx shaders/standard-shader-spec)))
+
 
 ;; Used for determining frame delta, the time between each frame.
 (defonce time-of-last-frame (volatile! 0))

--- a/src/weather_magic/ui.cljs
+++ b/src/weather_magic/ui.cljs
@@ -63,9 +63,9 @@
   []
   [:div {:id "shader-selection-container"}
    [button "Go to map"          swap!  state/intro-visible  #(swap! state/intro-visible hide-unhide)]
-   [button "Standard shader"    reset! state/current-shader (compile-shader shaders/standard-shader-spec)]
-   [button "Blend shader"       reset! state/current-shader (compile-shader shaders/blend-shader-spec)]
-   [button "Temperature shader" reset! state/current-shader (compile-shader shaders/temperature-shader-spec)]])
+   [button "Standard shader"    reset! state/current-shader-key :standard]
+   [button "Blend shader"       reset! state/current-shader-key :blend]
+   [button "Temperature shader" reset! state/current-shader-key :temp]])
 
 (defn map-ui-blur []
   "What hides the map UI."

--- a/src/weather_magic/ui.cljs
+++ b/src/weather_magic/ui.cljs
@@ -1,11 +1,12 @@
 (ns weather-magic.ui
   (:require
-   [weather-magic.models :as models]
-   [weather-magic.state :as state]
-   [weather-magic.world :as world]
-   [weather-magic.shaders :as shaders]
-   [weather-magic.util  :as util]
-   [reagent.core :as reagent :refer [atom]]))
+   [weather-magic.models   :as models]
+   [weather-magic.state    :as state]
+   [weather-magic.world    :as world]
+   [weather-magic.shaders  :as shaders]
+   [weather-magic.util     :as util]
+   [reagent.core           :as reagent :refer [atom]]
+   [thi.ng.geom.gl.shaders :as sh]))
 
 (enable-console-print!)
 
@@ -54,14 +55,17 @@
    [button "Europe" reset! state/earth-animation-fn world/show-europe!]
    [button "Northpole Up" reset! state/earth-animation-fn world/northpole-up!]])
 
+(defn compile-shader [s]
+  (sh/make-shader-from-spec state/gl-ctx s))
+
 (defn shader-selection-buttons
   "Buttons for choosing shader"
   []
   [:div {:id "shader-selection-container"}
    [button "Go to map"          swap!  state/intro-visible  #(swap! state/intro-visible hide-unhide)]
-   [button "Standard shader"    reset! state/current-shader shaders/standard-shader-spec]
-   [button "Blend shader"       reset! state/current-shader shaders/blend-shader-spec]
-   [button "Temperature shader" reset! state/current-shader shaders/temperature-shader-spec]])
+   [button "Standard shader"    reset! state/current-shader (compile-shader shaders/standard-shader-spec)]
+   [button "Blend shader"       reset! state/current-shader (compile-shader shaders/blend-shader-spec)]
+   [button "Temperature shader" reset! state/current-shader (compile-shader shaders/temperature-shader-spec)]])
 
 (defn map-ui-blur []
   "What hides the map UI."

--- a/src/weather_magic/world.cljs
+++ b/src/weather_magic/world.cljs
@@ -1,12 +1,12 @@
 (ns weather-magic.world
   (:require
-   [weather-magic.models           :as models]
-   [weather-magic.state            :as state]
-   [weather-magic.textures         :as textures]
-   [thi.ng.geom.core               :as g]
-   [thi.ng.geom.matrix             :as mat :refer [M44]]
-   [thi.ng.math.core               :as m :refer [PI HALF_PI TWO_PI]]
-   [thi.ng.geom.vector             :as v :refer [vec3]]))
+   [weather-magic.models   :as models]
+   [weather-magic.state    :as state]
+   [weather-magic.textures :as textures]
+   [thi.ng.geom.core       :as g]
+   [thi.ng.geom.matrix     :as mat :refer [M44]]
+   [thi.ng.math.core       :as m]
+   [thi.ng.geom.vector     :as v   :refer [vec3]]))
 
 (defn show-europe!
   "Rotates the sphere so that Europe is shown."


### PR DESCRIPTION
This pull request makes no functional changes to the application itself. It only modifies how shaders are managed internally.

In order to test this code:

1. Run the master branch and measure processor and memory load.
2. Repeat the procedure with the branch lek-med-heapen checked out.

The below gallery clearly displays how the CPU load is lessened after this patch is applied: http://imgur.com/a/Ma9sM