### PR TITLE
Simple threshold to not draw contour map in the coolest areas

### DIFF
--- a/src/weather_magic/shaders.cljs
+++ b/src/weather_magic/shaders.cljs
@@ -52,7 +52,7 @@
 
     float alphaValue = clamp(15.0 / fov, 0.0, 1.0);
 
-    if (mod(temperature, 0.1) < threshold && fov < 50.0) {
+    if (mod(temperature, 0.1) < threshold && fov < 50.0 && temperature > 0.15) {
       if (temperature > 0.5 && temperature < 0.75) {
         outColor = vec4(0.5, 0.5, 0.5, alphaValue);
       } else if (temperature > 0.75) {


### PR DESCRIPTION
Whadda ya say? I don't think it is necessary to draw contours in the coolest areas since the interesting thing with our app is to show that it might get hotter. So the contour map is more important where it is hot. This commit will get rid of the white seas experienced earlier. Might need to be tuned when we use real data though. 

To test: See that we get no white seas in the contour map. 