### PR TITLE
Restructured render path so that we reuse WebGL buffers

### DIFF
--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -30,12 +30,6 @@
   (@state/earth-animation-fn delta-time)
   (m/* M44 @state/earth-orientation))
 
-(defn combine-model-and-camera
-  [model camera gl-ctx t]
-  (-> models/sphere
-      (gl/make-buffers-in-spec gl-ctx glc/static-draw)
-      (cam/apply camera)))
-
 (defn enable-shader-alpha-blending []
   (gl/prepare-render-state state/gl-ctx-left
                            {:blend true
@@ -57,8 +51,11 @@
       (doto state/gl-ctx-left
         (gl/clear-color-and-depth-buffer 0 0 0 1 1)
         (gl/draw-with-shader
-         (-> (combine-model-and-camera @state/model @state/camera-left state/gl-ctx-left t)
-             (assoc :shader (@state/current-shader-key state/shaders-left))
+         (-> (cam/apply (@state/current-model-key state/models-left) @state/camera-left)
+             (assoc
+              :shader
+              (@state/current-shader-key
+               state/shaders-left))
              (assoc-in [:uniforms :model] (set-model-matrix (- t @state/time-of-last-frame)))
              (assoc-in [:uniforms :year]  time)
              (assoc-in [:uniforms :range] range)
@@ -72,7 +69,7 @@
       (doto state/gl-ctx-right
         (gl/clear-color-and-depth-buffer 0 0 0 1 1)
         (gl/draw-with-shader
-         (-> (combine-model-and-camera @state/model @state/camera-right state/gl-ctx-right t)
+         (-> (cam/apply (@state/current-model-key state/models-right) @state/camera-right)
              (assoc :shader (@state/current-shader-key state/shaders-right))
              (assoc-in [:uniforms :model] (set-model-matrix (- t @state/time-of-last-frame)))
              (assoc-in [:uniforms :year]  time)

--- a/src/weather_magic/core.cljs
+++ b/src/weather_magic/core.cljs
@@ -5,6 +5,7 @@
    [weather-magic.shaders          :as shaders]
    [weather-magic.textures         :as textures]
    [weather-magic.event-handlers   :as event-handlers]
+   [weather-magic.models           :as models]
    [thi.ng.math.core               :as m   :refer [PI HALF_PI TWO_PI]]
    [thi.ng.geom.gl.core            :as gl]
    [thi.ng.geom.gl.webgl.constants :as glc]
@@ -31,8 +32,7 @@
 
 (defn combine-model-and-camera
   [model camera gl-ctx t]
-  (-> model
-      (gl/as-gl-buffer-spec {})
+  (-> models/sphere
       (gl/make-buffers-in-spec gl-ctx glc/static-draw)
       (cam/apply camera)))
 

--- a/src/weather_magic/models.cljs
+++ b/src/weather_magic/models.cljs
@@ -10,7 +10,7 @@
    [thi.ng.geom.attribs   :as attr]
    [thi.ng.geom.rect      :as rect]))
 
-(defonce sphere
+(def sphere
   (-> (s/sphere 1)
       (g/as-mesh
        {:mesh    (glm/gl-mesh 4096 (set '(:uv :vnorm)))
@@ -20,7 +20,7 @@
                   :vnorm (fn [_ _ v _] (m/normalize v))}})
       (gl/as-gl-buffer-spec {})))
 
-(defonce plane
+(def plane
   (-> (rect/rect 4 3)
       (g/as-mesh
        {:mesh    (glm/gl-mesh 4096 (set '(:uv :vnorm)))

--- a/src/weather_magic/models.cljs
+++ b/src/weather_magic/models.cljs
@@ -1,28 +1,31 @@
 (ns weather-magic.models
   (:require
-   [thi.ng.math.core :as m :refer [PI HALF_PI TWO_PI]]
-   [thi.ng.geom.core :as g]
+   [thi.ng.math.core      :as m]
+   [thi.ng.geom.core      :as g]
+   [thi.ng.geom.gl.core   :as gl]
    [thi.ng.geom.gl.glmesh :as glm]
-   [thi.ng.geom.vector :as v :refer [vec2 vec3]]
-   [thi.ng.geom.sphere :as s]
-   [thi.ng.geom.plane :as p]
-   [thi.ng.geom.attribs :as attr]
-   [thi.ng.geom.rect :as rect]))
+   [thi.ng.geom.vector    :refer [vec2]]
+   [thi.ng.geom.sphere    :as s]
+   [thi.ng.geom.plane     :as p]
+   [thi.ng.geom.attribs   :as attr]
+   [thi.ng.geom.rect      :as rect]))
 
 (defonce sphere
-  (g/as-mesh
-   (s/sphere 1)
-   {:mesh    (glm/gl-mesh 4096 (set '(:uv :vnorm)))
-    :res     32
-    :attribs {:uv    (attr/supplied-attrib
-                      :uv (fn [[u v]] (vec2 (- 1 u) v)))
-              :vnorm (fn [_ _ v _] (m/normalize v))}}))
+  (-> (s/sphere 1)
+      (g/as-mesh
+       {:mesh    (glm/gl-mesh 4096 (set '(:uv :vnorm)))
+        :res     32
+        :attribs {:uv    (attr/supplied-attrib
+                          :uv (fn [[u v]] (vec2 (- 1 u) v)))
+                  :vnorm (fn [_ _ v _] (m/normalize v))}})
+      (gl/as-gl-buffer-spec {})))
 
 (defonce plane
-  (g/as-mesh
-   (rect/rect 4 3)
-   {:mesh    (glm/gl-mesh 4096 (set '(:uv :vnorm)))
-    :res     32
-    :attribs {:uv    (attr/supplied-attrib
-                      :uv (fn [[u v]] (vec2 (- 1 u) v)))
-              :vnorm (fn [_ _ v _] (m/normalize v))}}))
+  (-> (rect/rect 4 3)
+      (g/as-mesh
+       {:mesh    (glm/gl-mesh 4096 (set '(:uv :vnorm)))
+        :res     32
+        :attribs {:uv    (attr/supplied-attrib
+                          :uv (fn [[u v]] (vec2 (- 1 u) v)))
+                  :vnorm (fn [_ _ v _] (m/normalize v))}})
+      (gl/as-gl-buffer-spec {})))

--- a/src/weather_magic/state.cljs
+++ b/src/weather_magic/state.cljs
@@ -1,14 +1,15 @@
 (ns weather-magic.state
   (:require
-   [weather-magic.models  :as models]
-   [thi.ng.geom.gl.camera :as cam]
-   [thi.ng.geom.gl.core   :as gl]
-   [weather-magic.shaders :as shaders]
-   [weather-magic.textures :as textures]
-   [thi.ng.geom.gl.shaders :as sh]
-   [thi.ng.geom.vector    :as v :refer [vec2 vec3]]
-   [thi.ng.geom.matrix    :as mat :refer [M44]]
-   [reagent.core          :refer [atom]]))
+   [weather-magic.models           :as models]
+   [weather-magic.shaders          :as shaders]
+   [weather-magic.textures         :as textures]
+   [thi.ng.geom.gl.camera          :as cam]
+   [thi.ng.geom.gl.core            :as gl]
+   [thi.ng.geom.gl.shaders         :as sh]
+   [thi.ng.geom.gl.webgl.constants :as glc]
+   [thi.ng.geom.vector             :refer [vec3]]
+   [thi.ng.geom.matrix             :refer [M44]]
+   [reagent.core                   :refer [atom]]))
 
 ;; Our WebGL context, given by the browser.
 (defonce gl-ctx-left  (gl/gl-context "left-canvas"))
@@ -41,7 +42,12 @@
 ;; Whether or not the landing page is visible.
 (defonce intro-visible (atom :visible))
 
-(defonce model         (atom models/sphere))
+;; The models with buffers prepared and ready for use by the program.
+(def models-left  {:sphere (gl/make-buffers-in-spec models/sphere gl-ctx-left  glc/static-draw)
+                   :plane  (gl/make-buffers-in-spec models/plane  gl-ctx-left  glc/static-draw)})
+(def models-right {:sphere (gl/make-buffers-in-spec models/sphere gl-ctx-right glc/static-draw)
+                   :plane  (gl/make-buffers-in-spec models/plane  gl-ctx-right glc/static-draw)})
+(defonce current-model-key (atom :sphere))
 
 (defonce textures-left        (atom (textures/load-base-textures gl-ctx-left)))
 (defonce textures-right       (atom (textures/load-base-textures gl-ctx-right)))
@@ -54,12 +60,12 @@
 (def shaders-right {:standard (sh/make-shader-from-spec gl-ctx-right shaders/standard-shader-spec)
                     :blend    (sh/make-shader-from-spec gl-ctx-right shaders/blend-shader-spec)
                     :temp     (sh/make-shader-from-spec gl-ctx-right shaders/temperature-shader-spec)})
-
 (defonce current-shader-key (atom :standard))
 
 ;; Used for determining frame delta, the time between each frame.
 (defonce time-of-last-frame (volatile! 0))
 
-(defonce model-coords (atom {:upper-left (vec3 0 0 0) :upper-right (vec3 0 0 0) :lower-left (vec3 0 0 0) :lower-right (vec3 0 0 0)}))
+(defonce model-coords (atom {:upper-left (vec3 0 0 0) :upper-right (vec3 0 0 0)
+                             :lower-left (vec3 0 0 0) :lower-right (vec3 0 0 0)}))
 
 (defonce pointer-zoom-info (atom {:delta-x 0 :delta-y 0 :total-steps 100 :current-step 0 :delta-zoom 0}))

--- a/src/weather_magic/world.cljs
+++ b/src/weather_magic/world.cljs
@@ -12,7 +12,7 @@
 (defn show-europe!
   "Rotates the sphere so that Europe is shown."
   [t]
-  (reset! state/model models/sphere)
+  (reset! state/current-model-key :sphere)
   (reset! state/base-texture-left (:earth @state/textures-left))
   (reset! state/earth-orientation (-> M44
                                       (g/rotate-x (m/radians 45))
@@ -22,7 +22,7 @@
 (defn northpole-up!
   "Rotates the sphere so that the northpole is up after panning."
   []
-  (reset! state/model models/sphere)
+  (reset! state/current-model-key :sphere)
   (reset! state/base-texture-left (:earth @state/textures-left))
   (reset! state/earth-orientation M44))
 
@@ -32,7 +32,7 @@
   [t]
   (swap!  state/textures-left merge
           (textures/load-texture-if-needed state/gl-ctx-left @state/textures-left "img/turkey.jpg"))
-  (reset! state/model models/plane)
+  (reset! state/current-model-key :plane)
   (reset! state/base-texture-left (:turkey @state/textures-left))
   (reset! state/earth-orientation (-> M44
                                       (g/translate (vec3 2 1.5 0))
@@ -43,7 +43,7 @@
 (defn spin-earth!
   "Rotates the sphere indefinitely."
   [delta-time]
-  (reset! state/model models/sphere)
+  (reset! state/current-model-key :sphere)
   (reset! state/base-texture-left (:earth @state/textures-left))
   (reset! state/earth-orientation (-> M44
                                       (g/rotate-y (m/radians delta-time))
@@ -52,7 +52,7 @@
 (defn reset-spin!
   "Rotates the sphere so that the northpole is up after panning."
   [delta-time]
-  (reset! state/model models/sphere)
+  (reset! state/current-model-key :sphere)
   (reset! state/base-texture-left (:earth @state/textures-left))
   (reset! state/earth-orientation M44)
   (reset! state/earth-animation-fn spin-earth!))


### PR DESCRIPTION
This PR should be without any functional modifications to the program. Its simply an internal reorganization of where work is done. Buffers are now allocated per gl-ctx at the start of the program in contrast to for every frame.

The performance impact of this change should be visible in [this imgur album](http://imgur.com/a/RWU1V) where we can see a decrease in stuttering and over all CPU usage.

But that's only a tiny part of the improvement. In order to validate that this patch set indeed does decrease the usage of driver allocated memory go ahead and compare the memory usage of  your browsers while running this and the master branch. A useful tool for Chrome is the internal process manager in which you can see the memory allocated for the GPU offloading process specifically.