### PR TITLE
zoom-alignment animation is now abrupted if zooming with mouse during

### DIFF
--- a/src/weather_magic/event_handlers.cljs
+++ b/src/weather_magic/event_handlers.cljs
@@ -148,6 +148,7 @@
         zoom-distance (* (* (.-deltaY event) zoom-level) 1.0E-3)]
     (swap! state/camera-left world/zoom-camera zoom-distance)
     (swap! state/camera-right world/zoom-camera zoom-distance)
+    (reset! state/earth-animation-fn world/stop-spin!)
     (if (neg? zoom-distance)
       (update-pan delta-x delta-y)
       (when (< camera-z-pos 3.0)


### PR DESCRIPTION
test by start zooming out direct after double click

issue  #117